### PR TITLE
Remove http from connect-src in CSP config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -9,7 +9,7 @@ const nextConfig = {
       style-src 'self' 'unsafe-inline';
       img-src 'self' blob: data: https://*.blob.vercel-storage.com https://placehold.co;
       font-src 'self';
-      connect-src 'self' https://www.payhere.lk https://sandbox.payhere.lk https://vitals.vercel-insights.com https://ralhumsports.lk http://ralhumsports.lk;
+      connect-src 'self' https://www.payhere.lk https://sandbox.payhere.lk https://vitals.vercel-insights.com https://ralhumsports.lk;
       frame-src 'self' https://www.payhere.lk https://sandbox.payhere.lk;
       object-src 'none';
       base-uri 'self';


### PR DESCRIPTION
Updated the Content Security Policy in next.config.mjs to remove the 'http://ralhumsports.lk' entry from connect-src, allowing only the secure 'https' version. This enhances security by restricting connections to HTTPS endpoints.