### PR TITLE
Enforce HTTPS in production via middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -2,6 +2,18 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
+  // --- Force HTTPS in production ---
+  if (
+    process.env.NODE_ENV === 'production' &&
+    request.headers.get('x-forwarded-proto') === 'http' &&
+    !request.headers.get('host')?.startsWith('localhost') &&
+    !request.headers.get('host')?.includes('vercel.app')
+  ) {
+    const url = request.nextUrl.clone()
+    url.protocol = 'https:'
+    url.host = request.headers.get('host') || ''
+    return NextResponse.redirect(url, 308)
+  }
   const { headers, nextUrl } = request
   const host = headers.get('host')
 


### PR DESCRIPTION
Added logic to redirect HTTP requests to HTTPS in production environments, excluding localhost and vercel.app hosts. This improves security by ensuring all traffic uses HTTPS.