### PR TITLE
Add preselected filter support for navigation flow

### DIFF
--- a/src/app/(frontend)/products/client-page.tsx
+++ b/src/app/(frontend)/products/client-page.tsx
@@ -173,40 +173,47 @@ export default function StorePage() {
     const search = searchParams.get('search')
     if (search) urlFilters.search = search
 
-    // Handle hierarchical categories (keep them separate, don't merge into categories array)
-    const sportsCategory = searchParams.get('sportsCategory')
-    const sport = searchParams.get('sport')
-    const sportsItem = searchParams.get('sportsItem')
+    // Handle preselected parameters from navigation (don't apply filters yet)
+    const preselected = searchParams.get('preselected')
+    const preselectValue = searchParams.get('preselectValue')
+    
+    // Only apply actual filters if no preselected parameters
+    if (!preselected && !preselectValue) {
+      // Handle hierarchical categories (keep them separate, don't merge into categories array)
+      const sportsCategory = searchParams.get('sportsCategory')
+      const sport = searchParams.get('sport')
+      const sportsItem = searchParams.get('sportsItem')
 
-    if (sportsCategory) urlFilters.sportsCategory = sportsCategory
-    if (sport) urlFilters.sport = sport
-    if (sportsItem) urlFilters.sportsItem = sportsItem
+      if (sportsCategory) urlFilters.sportsCategory = sportsCategory
+      if (sport) urlFilters.sport = sport
+      if (sportsItem) urlFilters.sportsItem = sportsItem
 
-    // Handle legacy categories array (only if no hierarchical filters)
-    if (!sportsCategory && !sport && !sportsItem) {
-      const categories = searchParams.get('categories')
-      if (categories) {
-        urlFilters.categories = categories.split(',')
+      // Handle legacy categories array (only if no hierarchical filters)
+      if (!sportsCategory && !sport && !sportsItem) {
+        const categories = searchParams.get('categories')
+        if (categories) {
+          urlFilters.categories = categories.split(',')
+        }
       }
+
+      // Handle brands (support both 'brand' and 'brands' parameters)
+      const brands = [...searchParams.getAll('brand'), ...searchParams.getAll('brands')].filter(
+        Boolean,
+      )
+      if (brands.length > 0) {
+        urlFilters.brands = brands
+      }
+
+      // Handle price range
+      const minPrice = searchParams.get('minPrice')
+      const maxPrice = searchParams.get('maxPrice')
+      if (minPrice) urlFilters.minPrice = parseInt(minPrice)
+      if (maxPrice) urlFilters.maxPrice = parseInt(maxPrice)
+
+      // Handle stock filter
+      const inStock = searchParams.get('inStock')
+      if (inStock === 'true') urlFilters.inStock = true
     }
-
-    // Handle brands (support both 'brand' and 'brands' parameters)
-    const brands = [...searchParams.getAll('brand'), ...searchParams.getAll('brands')].filter(
-      Boolean,
-    )
-    if (brands.length > 0) {
-      urlFilters.brands = brands
-    }
-
-    // Handle price range
-    const minPrice = searchParams.get('minPrice')
-    const maxPrice = searchParams.get('maxPrice')
-    if (minPrice) urlFilters.minPrice = parseInt(minPrice)
-    if (maxPrice) urlFilters.maxPrice = parseInt(maxPrice)
-
-    // Handle stock filter
-    const inStock = searchParams.get('inStock')
-    if (inStock === 'true') urlFilters.inStock = true
 
     setCurrentFilters(urlFilters)
   }, [searchParams])

--- a/src/components/navigation.tsx
+++ b/src/components/navigation.tsx
@@ -278,7 +278,35 @@ export default function EnhancedNavigation() {
     { name: 'Verify', href: '/products/verify' },
   ]
 
-  // Build filter URL based on current selection for hierarchical filtering
+  // Build preselect URL for navigation (doesn't apply filters immediately)
+  const buildPreselectUrl = (params: {
+    sportsCategory?: string
+    sport?: string
+    sportsItem?: string
+    brand?: string
+  }) => {
+    const searchParams = new URLSearchParams()
+
+    // Use preselect parameters instead of direct filtering
+    if (params.sportsCategory) {
+      searchParams.append('preselected', 'sportsCategory')
+      searchParams.append('preselectValue', params.sportsCategory)
+    } else if (params.sport) {
+      searchParams.append('preselected', 'sport')
+      searchParams.append('preselectValue', params.sport)
+    } else if (params.sportsItem) {
+      searchParams.append('preselected', 'sportsItem')
+      searchParams.append('preselectValue', params.sportsItem)
+    } else if (params.brand) {
+      searchParams.append('preselected', 'brand')
+      searchParams.append('preselectValue', params.brand)
+    }
+
+    const queryString = searchParams.toString()
+    return `/products${queryString ? `?${queryString}` : ''}`
+  }
+
+  // Build filter URL for immediate filtering (used when user confirms selection)
   const buildFilterUrl = (params: {
     sportsCategory?: string
     sport?: string
@@ -288,24 +316,14 @@ export default function EnhancedNavigation() {
   }) => {
     const searchParams = new URLSearchParams()
 
-    // Build hierarchical category path
-    const categories: string[] = []
-    if (params.sportsCategory) categories.push(params.sportsCategory)
-    if (params.sport) categories.push(params.sport)
-    if (params.sportsItem) categories.push(params.sportsItem)
-
-    if (categories.length > 0) {
-      searchParams.append('categories', categories.join(','))
-    }
-
     // Add individual hierarchical filters for proper filter display
     if (params.sportsCategory) searchParams.append('sportsCategory', params.sportsCategory)
     if (params.sport) searchParams.append('sport', params.sport)
     if (params.sportsItem) searchParams.append('sportsItem', params.sportsItem)
 
-    if (params.brand) searchParams.append('brands', params.brand)
+    if (params.brand) searchParams.append('brand', params.brand)
     if (params.brands && params.brands.length > 0) {
-      searchParams.append('brands', params.brands.join(','))
+      params.brands.forEach(brand => searchParams.append('brand', brand))
     }
 
     const queryString = searchParams.toString()
@@ -315,8 +333,8 @@ export default function EnhancedNavigation() {
   // Handle category selection (show next layer)
   const handleCategorySelect = (categorySlug: string) => {
     if (selectedSportsCategory === categorySlug) {
-      // If already selected, go to products page
-      window.location.href = buildFilterUrl({ sportsCategory: categorySlug })
+      // If already selected, go to products page with preselected category
+      window.location.href = buildPreselectUrl({ sportsCategory: categorySlug })
       closeMegaMenuImmediately()
     } else {
       // Select this category and show sports layer
@@ -329,11 +347,8 @@ export default function EnhancedNavigation() {
 
   const handleSportSelect = (categorySlug: string, sportSlug: string) => {
     if (selectedSport === sportSlug) {
-      // If already selected, go to products page
-      window.location.href = buildFilterUrl({
-        sportsCategory: categorySlug,
-        sport: sportSlug,
-      })
+      // If already selected, go to products page with preselected sport
+      window.location.href = buildPreselectUrl({ sport: sportSlug })
       closeMegaMenuImmediately()
     } else {
       // Select this sport and show sports items layer
@@ -342,31 +357,24 @@ export default function EnhancedNavigation() {
     }
   }
 
-  // Handle navigation clicks with proper hierarchical filtering (for final selection)
+  // Handle navigation clicks with preselection (for final selection)
   const handleCategoryClick = (categorySlug: string) => {
-    window.location.href = buildFilterUrl({ sportsCategory: categorySlug })
+    window.location.href = buildPreselectUrl({ sportsCategory: categorySlug })
     closeMegaMenuImmediately()
   }
 
   const handleSportClick = (categorySlug: string, sportSlug: string) => {
-    window.location.href = buildFilterUrl({
-      sportsCategory: categorySlug,
-      sport: sportSlug,
-    })
+    window.location.href = buildPreselectUrl({ sport: sportSlug })
     closeMegaMenuImmediately()
   }
 
   const handleSportsItemClick = (categorySlug: string, sportSlug: string, itemSlug: string) => {
-    window.location.href = buildFilterUrl({
-      sportsCategory: categorySlug,
-      sport: sportSlug,
-      sportsItem: itemSlug,
-    })
+    window.location.href = buildPreselectUrl({ sportsItem: itemSlug })
     closeMegaMenuImmediately()
   }
 
   const handleBrandClick = (brandSlug: string) => {
-    window.location.href = buildFilterUrl({ brand: brandSlug })
+    window.location.href = buildPreselectUrl({ brand: brandSlug })
     closeMegaMenuImmediately()
   }
 
@@ -711,25 +719,8 @@ export default function EnhancedNavigation() {
                               key={brand.id}
                               className="group p-3 rounded-lg cursor-pointer transition-all duration-200 hover:bg-white hover:shadow-md border border-transparent hover:border-purple-200"
                               onClick={() => {
-                                const url =
-                                  hoveredSportsItem && hoveredSport && hoveredSportsCategory
-                                    ? buildFilterUrl({
-                                        sportsCategory: hoveredSportsCategory ?? undefined,
-                                        sport: hoveredSport,
-                                        sportsItem: hoveredSportsItem,
-                                        brand: brand.slug,
-                                      })
-                                    : hoveredSport && hoveredSportsCategory
-                                      ? buildFilterUrl({
-                                          sportsCategory: hoveredSportsCategory,
-                                          sport: hoveredSport,
-                                          brand: brand.slug,
-                                        })
-                                      : buildFilterUrl({
-                                          sportsCategory: hoveredSportsCategory ?? undefined,
-                                          brand: brand.slug,
-                                        })
-                                window.location.href = url
+                                // Use preselect URL for brand selection
+                                window.location.href = buildPreselectUrl({ brand: brand.slug })
                                 closeMegaMenuImmediately()
                               }}
                             >
@@ -769,25 +760,8 @@ export default function EnhancedNavigation() {
                         key={brand.id}
                         className="group p-2 rounded-lg cursor-pointer transition-all duration-200 hover:bg-white hover:shadow-sm border border-transparent hover:border-gray-200"
                         onClick={() => {
-                          const url =
-                            hoveredSportsItem && selectedSport
-                              ? buildFilterUrl({
-                                  sportsCategory: selectedSportsCategory,
-                                  sport: selectedSport,
-                                  sportsItem: hoveredSportsItem,
-                                  brand: brand.slug,
-                                })
-                              : hoveredSport && selectedSportsCategory
-                                ? buildFilterUrl({
-                                    sportsCategory: selectedSportsCategory,
-                                    sport: hoveredSport,
-                                    brand: brand.slug,
-                                  })
-                                : buildFilterUrl({
-                                    sportsCategory: selectedSportsCategory,
-                                    brand: brand.slug,
-                                  })
-                          window.location.href = url
+                          // Use preselect URL for brand selection
+                          window.location.href = buildPreselectUrl({ brand: brand.slug })
                           closeMegaMenuImmediately()
                         }}
                       >

--- a/src/components/product-filters.tsx
+++ b/src/components/product-filters.tsx
@@ -91,7 +91,7 @@ export function EnhancedProductFilters({
   loading = false,
   onApplyFilters,
 }: ProductFiltersProps) {
-  const { filters, setMultipleFilters, clearFilters } = useProductFilters()
+  const { filters, setMultipleFilters, clearFilters, getPreselectedValues } = useProductFilters()
 
   // Pending filters state (before applying)
   const [pendingFilters, setPendingFilters] = useState<PendingFilters>({
@@ -130,9 +130,11 @@ export function EnhancedProductFilters({
     )
   }, [pendingFilters.sport, hierarchicalCategories.sportsItems])
 
-  // Initialize pending filters from URL filters
+  // Initialize pending filters from URL filters and preselected values
   useEffect(() => {
-    setPendingFilters({
+    const preselected = getPreselectedValues()
+    
+    const newPendingFilters: PendingFilters = {
       search: filters.search || '',
       sportsCategory: filters.sportsCategory || ALL_CATEGORIES,
       sport: filters.sport || ALL_SPORTS,
@@ -141,8 +143,26 @@ export function EnhancedProductFilters({
       priceRange: [filters.minPrice || priceRange.min, filters.maxPrice || priceRange.max],
       inStock: filters.inStock || false,
       sort: `${filters.sort || 'createdAt'}-${filters.order || 'desc'}`,
-    })
-  }, [filters, priceRange])
+    }
+
+    // Handle preselected values from navigation
+    if (preselected.type && preselected.value) {
+      if (preselected.type === 'sportsCategory') {
+        newPendingFilters.sportsCategory = preselected.value
+        newPendingFilters.sport = ALL_SPORTS
+        newPendingFilters.sportsItem = ALL_ITEMS
+      } else if (preselected.type === 'sport') {
+        newPendingFilters.sport = preselected.value
+        newPendingFilters.sportsItem = ALL_ITEMS
+      } else if (preselected.type === 'sportsItem') {
+        newPendingFilters.sportsItem = preselected.value
+      } else if (preselected.type === 'brand') {
+        newPendingFilters.brands = [preselected.value]
+      }
+    }
+
+    setPendingFilters(newPendingFilters)
+  }, [filters, priceRange, getPreselectedValues])
 
   // Calculate active filters count
   const activeFiltersCount = useMemo(() => {
@@ -175,8 +195,10 @@ export function EnhancedProductFilters({
 
   const handleApplyFilters = useCallback(() => {
     const [sortBy, sortOrder] = pendingFilters.sort.split('-')
+    const preselected = getPreselectedValues()
 
-    const newFilters: any = {
+    // When applying filters with preselected values, we need to set up the proper hierarchy
+    let finalFilters: any = {
       search: pendingFilters.search || undefined,
       sportsCategory:
         pendingFilters.sportsCategory !== ALL_CATEGORIES
@@ -194,16 +216,44 @@ export function EnhancedProductFilters({
       order: sortOrder,
     }
 
+    // Handle preselected values - ensure proper hierarchy
+    if (preselected.type && preselected.value) {
+      if (preselected.type === 'sportsCategory') {
+        finalFilters.sportsCategory = preselected.value
+      } else if (preselected.type === 'sport') {
+        finalFilters.sport = preselected.value
+        // Find parent category for sport
+        const sport = hierarchicalCategories.sports.find(s => s.slug === preselected.value)
+        if (sport?.parentCategory) {
+          finalFilters.sportsCategory = sport.parentCategory.slug
+        }
+      } else if (preselected.type === 'sportsItem') {
+        finalFilters.sportsItem = preselected.value
+        // Find parent sport and category
+        const item = hierarchicalCategories.sportsItems.find(i => i.slug === preselected.value)
+        if (item?.parentCategory) {
+          finalFilters.sport = item.parentCategory.slug
+          // Find sport's parent category
+          const sport = hierarchicalCategories.sports.find(s => s.slug === item.parentCategory?.slug)
+          if (sport?.parentCategory) {
+            finalFilters.sportsCategory = sport.parentCategory.slug
+          }
+        }
+      } else if (preselected.type === 'brand') {
+        finalFilters.brands = [preselected.value]
+      }
+    }
+
     // Remove undefined values
-    Object.keys(newFilters).forEach((key) => {
-      if (newFilters[key] === undefined) {
-        delete newFilters[key]
+    Object.keys(finalFilters).forEach((key) => {
+      if (finalFilters[key] === undefined) {
+        delete finalFilters[key]
       }
     })
 
-    setMultipleFilters(newFilters)
+    setMultipleFilters(finalFilters)
     onApplyFilters?.()
-  }, [pendingFilters, priceRange, setMultipleFilters, onApplyFilters])
+  }, [pendingFilters, priceRange, setMultipleFilters, onApplyFilters, getPreselectedValues, hierarchicalCategories])
 
   const handleReset = useCallback(() => {
     setPendingFilters({
@@ -294,6 +344,52 @@ export function EnhancedProductFilters({
       </CardHeader>
 
       <CardContent className="space-y-3 sm:space-y-4 pb-3 sm:pb-4">
+        {/* Preselected Filter Notice */}
+        {(() => {
+          const preselected = getPreselectedValues()
+          if (preselected.type && preselected.value) {
+            const getPreselectedName = () => {
+              if (preselected.type === 'sportsCategory') {
+                const category = hierarchicalCategories.sportsCategories.find(c => c.slug === preselected.value)
+                return category?.name || preselected.value
+              } else if (preselected.type === 'sport') {
+                const sport = hierarchicalCategories.sports.find(s => s.slug === preselected.value)
+                return sport?.name || preselected.value
+              } else if (preselected.type === 'sportsItem') {
+                const item = hierarchicalCategories.sportsItems.find(i => i.slug === preselected.value)
+                return item?.name || preselected.value
+              } else if (preselected.type === 'brand') {
+                const brand = brands.find(b => b.slug === preselected.value)
+                return brand?.name || preselected.value
+              }
+              return preselected.value
+            }
+
+            return (
+              <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h4 className="font-semibold text-blue-900 mb-1">Selected from Navigation</h4>
+                    <p className="text-blue-700 text-sm">
+                      {preselected.type === 'sportsCategory' ? 'Category' : 
+                       preselected.type === 'sport' ? 'Sport' :
+                       preselected.type === 'sportsItem' ? 'Equipment' : 'Brand'}: <strong>{getPreselectedName()}</strong>
+                    </p>
+                  </div>
+                  <Button 
+                    size="sm" 
+                    onClick={handleApplyFilters}
+                    className="bg-blue-600 hover:bg-blue-700 text-white"
+                  >
+                    Apply Filter
+                  </Button>
+                </div>
+              </div>
+            )
+          }
+          return null
+        })()}
+
         {/* Search */}
         <Collapsible
           open={expandedSections.search}

--- a/src/hooks/useProductFilters.ts
+++ b/src/hooks/useProductFilters.ts
@@ -32,37 +32,44 @@ export function useProductFilters() {
     const search = searchParams.get('search')
     if (search) urlFilters.search = search
 
-    // Handle layered categories - can have multiple levels
-    const categories = searchParams.get('categories')
-    if (categories) urlFilters.categories = categories.split(',')
+    // Handle preselected parameters from navigation - these don't apply filters yet
+    const preselected = searchParams.get('preselected')
+    const preselectValue = searchParams.get('preselectValue')
     
-    // Handle individual category levels for hierarchical filtering
-    const sportsCategory = searchParams.get('sportsCategory')
-    if (sportsCategory) urlFilters.sportsCategory = sportsCategory
-    
-    const sport = searchParams.get('sport')
-    if (sport) urlFilters.sport = sport
-    
-    const sportsItem = searchParams.get('sportsItem')
-    if (sportsItem) urlFilters.sportsItem = sportsItem
+    // Only parse filter parameters if no preselected values
+    if (!preselected && !preselectValue) {
+      // Handle layered categories - can have multiple levels
+      const categories = searchParams.get('categories')
+      if (categories) urlFilters.categories = categories.split(',')
+      
+      // Handle individual category levels for hierarchical filtering
+      const sportsCategory = searchParams.get('sportsCategory')
+      if (sportsCategory) urlFilters.sportsCategory = sportsCategory
+      
+      const sport = searchParams.get('sport')
+      if (sport) urlFilters.sport = sport
+      
+      const sportsItem = searchParams.get('sportsItem')
+      if (sportsItem) urlFilters.sportsItem = sportsItem
 
-    const brands = searchParams.getAll('brand')
-    if (brands.length > 0) urlFilters.brands = brands
+      const brands = searchParams.getAll('brand')
+      if (brands.length > 0) urlFilters.brands = brands
 
-    const minPrice = searchParams.get('minPrice')
-    if (minPrice) urlFilters.minPrice = Number.parseInt(minPrice)
+      const minPrice = searchParams.get('minPrice')
+      if (minPrice) urlFilters.minPrice = Number.parseInt(minPrice)
 
-    const maxPrice = searchParams.get('maxPrice')
-    if (maxPrice) urlFilters.maxPrice = Number.parseInt(maxPrice)
+      const maxPrice = searchParams.get('maxPrice')
+      if (maxPrice) urlFilters.maxPrice = Number.parseInt(maxPrice)
 
-    const inStock = searchParams.get('inStock')
-    if (inStock === 'true') urlFilters.inStock = true
+      const inStock = searchParams.get('inStock')
+      if (inStock === 'true') urlFilters.inStock = true
 
-    const sort = searchParams.get('sort')
-    if (sort) urlFilters.sort = sort
+      const sort = searchParams.get('sort')
+      if (sort) urlFilters.sort = sort
 
-    const order = searchParams.get('order')
-    if (order === 'asc' || order === 'desc') urlFilters.order = order
+      const order = searchParams.get('order')
+      if (order === 'asc' || order === 'desc') urlFilters.order = order
+    }
 
     setFilters(urlFilters)
   }, [searchParams])
@@ -159,6 +166,17 @@ export function useProductFilters() {
     [updateURL],
   )
 
+  // Get preselected values from navigation
+  const getPreselectedValues = useCallback(() => {
+    const preselected = searchParams.get('preselected')
+    const preselectValue = searchParams.get('preselectValue')
+    
+    return {
+      type: preselected,
+      value: preselectValue,
+    }
+  }, [searchParams])
+
   return {
     filters,
     loading,
@@ -168,5 +186,6 @@ export function useProductFilters() {
     navigateToProducts,
     setMultipleFilters,
     setLoading,
+    getPreselectedValues,
   }
 }


### PR DESCRIPTION
Introduces 'preselected' and 'preselectValue' URL parameters to enable navigation-driven preselection of filters without immediately applying them. Updates navigation, product filters, and filter hooks to handle preselected values, display a notice, and ensure correct filter hierarchy is set when the user applies filters. This improves the UX for users navigating via category, sport, item, or brand links.