### PR TITLE
Redirect immediately after payment success

### DIFF
--- a/src/components/payherecheckout.tsx
+++ b/src/components/payherecheckout.tsx
@@ -59,16 +59,13 @@ export function PayHereCheckout({
       paymentLogger.success(orderId)
       setIsProcessing(false)
 
-      // Show success toast with shorter duration
-      const successToast = toast.success('Payment completed successfully!', {
+      // Immediately redirect - don't delay
+      onSuccess?.(orderId)
+
+      // Show success message
+      toast.success('Payment completed successfully!', {
         duration: 2000,
       })
-
-      // Clear the toast and redirect after a short delay
-      setTimeout(() => {
-        toast.dismiss(successToast)
-        onSuccess?.(orderId)
-      }, 1500)
     }
 
     window.payhere.onDismissed = () => {
@@ -103,7 +100,7 @@ export function PayHereCheckout({
       toast.error(userMessage, { duration: 6000 })
       onError?.(error)
     }
-  }, [isLoaded, onSuccess, onError, onDismiss])
+  }, [isLoaded, onSuccess, onError, onDismiss, orderId])
 
   const handlePayment = async () => {
     setIsProcessing(true)


### PR DESCRIPTION
Updated the PayHereCheckout component to trigger the onSuccess callback immediately after a successful payment, instead of waiting for a toast duration. The success toast is still shown, but the redirect is no longer delayed.