### PR TITLE
Force static generation and update metadata base URL

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -5,7 +5,9 @@
       "Bash(pnpm lint:*)",
       "Bash(mv:*)",
       "Bash(npm run lint)",
-      "Bash(pnpm add:*)"
+      "Bash(pnpm add:*)",
+      "Bash(curl:*)",
+      "Bash(npx tsc:*)"
     ],
     "deny": []
   }

--- a/src/app/(frontend)/about/page.tsx
+++ b/src/app/(frontend)/about/page.tsx
@@ -4,6 +4,9 @@ import type { Metadata } from 'next'
 // Import the existing client component
 import AboutClientPage from './client-page'
 
+// Force static generation - this ensures metadata is server-rendered
+export const dynamic = 'force-static'
+
 export const metadata: Metadata = {
   title: 'About Ralhum Sports Sri Lanka - 30+ Years of Sports Excellence',
   description:

--- a/src/app/(frontend)/brands/page.tsx
+++ b/src/app/(frontend)/brands/page.tsx
@@ -4,6 +4,9 @@ import type { Metadata } from 'next'
 // Import the existing client component
 import BrandsClientPage from './client-page'
 
+// Force static generation - this ensures metadata is server-rendered
+export const dynamic = 'force-static'
+
 export const metadata: Metadata = {
   title: 'Official Sports Brands at Ralhum Sports Sri Lanka | Gray-Nicolls, Gilbert, Molten',
   description:

--- a/src/app/(frontend)/layout.tsx
+++ b/src/app/(frontend)/layout.tsx
@@ -23,7 +23,7 @@ const inter = Inter({
 })
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://www.ralhumsports.lk'),
+  metadataBase: new URL(process.env.VERCEL_ENV === 'production' ? 'https://www.ralhumsports.lk' : 'http://localhost:3000'),
   title: {
     template: '%s | Ralhum Sports Sri Lanka - Premium Sports Equipment Store',
     default: 'Ralhum Sports Sri Lanka - Premium Sports Equipment & Gear | ralhumsports.lk',

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -6,6 +6,9 @@ import Heritage from '@/components/heritage'
 import ContactCTA from '@/components/contact-cta'
 import type { Metadata } from 'next'
 
+// Force static generation - this ensures metadata is server-rendered
+export const dynamic = 'force-static'
+
 export const metadata: Metadata = {
   title: "Ralhum Sports Sri Lanka - Premium Sports Equipment Store | ralhumsports.lk",
   description:

--- a/src/app/(frontend)/products/page.tsx
+++ b/src/app/(frontend)/products/page.tsx
@@ -5,6 +5,9 @@ import type { Metadata } from 'next'
 // Import the existing client component
 import ProductsClientPage from './client-page'
 
+// Force static generation - this ensures metadata is server-rendered
+export const dynamic = 'force-static'
+
 export const metadata: Metadata = productsMetadata
 
 export default function ProductsPage() {

--- a/src/lib/metadata-utils.ts
+++ b/src/lib/metadata-utils.ts
@@ -2,12 +2,12 @@ import type { Metadata } from 'next'
 
 /**
  * Get the appropriate base URL for the current environment
- * Follows Vercel best practices for URL resolution
+ * Follows Vercel best practices for URL resolution and ensures www consistency
  */
 export function getBaseUrl(): string {
-  // Production environment - always use custom domain
+  // Production environment - always use www subdomain for consistency
   if (process.env.VERCEL_ENV === 'production') {
-    return 'https://ralhumsports.lk'
+    return 'https://www.ralhumsports.lk'
   }
 
   // Preview environment - use project production URL if available


### PR DESCRIPTION
Added 'force-static' export to key frontend pages to ensure metadata is server-rendered. Updated metadataBase and getBaseUrl to use 'https://www.ralhumsports.lk' in production for consistency. Also extended allowed bash commands in local settings.